### PR TITLE
chore: release v1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-repository-bootstrap",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Reusable Pi skill for safe, repeatable GitHub repository bootstrap.",
   "private": true,
   "type": "module",


### PR DESCRIPTION
Closes #7

## Type

- [x] Maintenance/tooling

## Summary

- Bump the package version from `1.0.0` to `1.1.0`.
- Publish the additive Linux, macOS, and Windows support already merged through PR #6.

## Changes

| File | Change |
|------|--------|
| `package.json` | Set the release version to `1.1.0`. |

## Test plan

- [x] `npm test` (37 passed)
- [x] `npm pack --dry-run`
- [x] `git diff --check`
- [x] Confirmed tag and release `v1.1.0` do not already exist

## Contributor checklist

- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Tests pass
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers
